### PR TITLE
Resolve on julia version 1.10.2

### DIFF
--- a/.github/workflows/AFALtests.yml
+++ b/.github/workflows/AFALtests.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10.1'
+          - '1.10.2'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10.1'
+          - '1.10.2'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.10.1'
+          version: '1.10.2'
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -40,31 +40,43 @@ jobs:
       - name: Install the project
         run: |
           ./INSTALL.sh
+          cat juliaversioninstalled
           if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.2" ]; then exit 1; fi
-          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit 1; fi
+          grep julia_version Manifest.toml
+          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit 2; fi
       - name: Install for a different julia version
         run: |
           ./INSTALL.sh -v 1.10.0
+          cat juliaversioninstalled
           if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.0" ]; then exit 1; fi
-          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit 1; fi
+          grep julia_version Manifest.toml
+          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit 2; fi
       - name: Install and resolve for a different julia version
         run: |
           ./INSTALL.sh -v 1.10.0 -r
+          cat juliaversioninstalled
           if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.0" ]; then exit 1; fi
-          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.0"' ]; then exit 1; fi
+          grep julia_version Manifest.toml
+          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.0"' ]; then exit 2; fi
       - name: Reinstall the project
         run: |
           ./INSTALL.sh -r
+          cat juliaversioninstalled
           if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.2" ]; then exit 1; fi
-          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit 1; fi
+          grep julia_version Manifest.toml
+          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit 2; fi
       - name: Install for a different julia version (positional)
         run: |
           ./INSTALL.sh 1.10.0
+          cat juliaversioninstalled
           if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.0" ]; then exit 1; fi
-          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit 1; fi
+          grep julia_version Manifest.toml
+          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit 2; fi
       - name: Install and resolve for a different julia version (positional)
         run: |
           ./INSTALL.sh 1.10.0 -r
+          cat juliaversioninstalled
           if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.0" ]; then exit 1; fi
-          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.0"' ]; then exit 1; fi
+          grep julia_version Manifest.toml
+          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.0"' ]; then exit 2; fi
 

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -38,7 +38,33 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v4
       - name: Install the project
-        run: ./INSTALL.sh
+        run: |
+          ./INSTALL.sh
+          if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.2" ]; then exit(1); fi
+          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit(1); fi
       - name: Install for a different julia version
-        run: ./INSTALL.sh 1.10.0
+        run: |
+          ./INSTALL.sh -v 1.10.0
+          if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.0" ]; then exit(1); fi
+          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit(1); fi
+      - name: Install and resolve for a different julia version
+        run: |
+          ./INSTALL.sh -v 1.10.0 -r
+          if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.0" ]; then exit(1); fi
+          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.0"' ]; then exit(1); fi
+      - name: Reinstall the project
+        run: |
+          ./INSTALL.sh -r
+          if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.2" ]; then exit(1); fi
+          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit(1); fi
+      - name: Install for a different julia version (positional)
+        run: |
+          ./INSTALL.sh 1.10.0
+          if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.0" ]; then exit(1); fi
+          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit(1); fi
+      - name: Install and resolve for a different julia version (positional)
+        run: |
+          ./INSTALL.sh 1.10.0 -r
+          if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.0" ]; then exit(1); fi
+          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.0"' ]; then exit(1); fi
 

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -40,31 +40,31 @@ jobs:
       - name: Install the project
         run: |
           ./INSTALL.sh
-          if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.2" ]; then exit(1); fi
-          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit(1); fi
+          if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.2" ]; then exit 1; fi
+          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit 1; fi
       - name: Install for a different julia version
         run: |
           ./INSTALL.sh -v 1.10.0
-          if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.0" ]; then exit(1); fi
-          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit(1); fi
+          if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.0" ]; then exit 1; fi
+          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit 1; fi
       - name: Install and resolve for a different julia version
         run: |
           ./INSTALL.sh -v 1.10.0 -r
-          if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.0" ]; then exit(1); fi
-          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.0"' ]; then exit(1); fi
+          if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.0" ]; then exit 1; fi
+          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.0"' ]; then exit 1; fi
       - name: Reinstall the project
         run: |
           ./INSTALL.sh -r
-          if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.2" ]; then exit(1); fi
-          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit(1); fi
+          if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.2" ]; then exit 1; fi
+          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit 1; fi
       - name: Install for a different julia version (positional)
         run: |
           ./INSTALL.sh 1.10.0
-          if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.0" ]; then exit(1); fi
-          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit(1); fi
+          if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.0" ]; then exit 1; fi
+          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit 1; fi
       - name: Install and resolve for a different julia version (positional)
         run: |
           ./INSTALL.sh 1.10.0 -r
-          if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.0" ]; then exit(1); fi
-          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.0"' ]; then exit(1); fi
+          if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.0" ]; then exit 1; fi
+          if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.0"' ]; then exit 1; fi
 

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -74,7 +74,7 @@ jobs:
           if [ "$(grep julia_version Manifest.toml)" != 'julia_version = "1.10.2"' ]; then exit 2; fi
       - name: Install and resolve for a different julia version (positional)
         run: |
-          ./INSTALL.sh 1.10.0 -r
+          ./INSTALL.sh -r 1.10.0
           cat juliaversioninstalled
           if [ "$(cat juliaversioninstalled)" != "RossbyWaveJuliaVersion=1.10.0" ]; then exit 1; fi
           grep julia_version Manifest.toml

--- a/ApproxFunAssociatedLegendre/Manifest.toml
+++ b/ApproxFunAssociatedLegendre/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.1"
+julia_version = "1.10.2"
 manifest_format = "2.0"
 project_hash = "9e79c794a4c8a7e928c19489a54703e28330206d"
 
@@ -107,9 +107,9 @@ version = "1.0.2"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
-git-tree-sha1 = "75bd5b6fc5089df449b5d35fa501c846c9b6549b"
+git-tree-sha1 = "c955881e3c981181362ae4088b35995446298b80"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.12.0"
+version = "4.14.0"
 weakdeps = ["Dates", "LinearAlgebra"]
 
     [deps.Compat.extensions]
@@ -154,9 +154,9 @@ version = "0.9.3"
 
 [[deps.DomainSets]]
 deps = ["CompositeTypes", "IntervalSets", "LinearAlgebra", "Random", "StaticArrays"]
-git-tree-sha1 = "4d18ed7069d7fc137089394b88eeedf7b5409120"
+git-tree-sha1 = "72bb555dc909a0932325f7dcc8c046ecb5dd39c8"
 uuid = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
-version = "0.7.3"
+version = "0.7.7"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
@@ -265,13 +265,14 @@ deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[deps.IntervalSets]]
-git-tree-sha1 = "581191b15bcb56a2aa257e9c160085d0f128a380"
+git-tree-sha1 = "dba9ddf07f77f60450fe5d2e2beb9854d9a49bd0"
 uuid = "8197267c-284f-5f27-9208-e0e47529a953"
-version = "0.7.9"
-weakdeps = ["Random", "Statistics"]
+version = "0.7.10"
+weakdeps = ["Random", "RecipesBase", "Statistics"]
 
     [deps.IntervalSets.extensions]
     IntervalSetsRandomExt = "Random"
+    IntervalSetsRecipesBaseExt = "RecipesBase"
     IntervalSetsStatisticsExt = "Statistics"
 
 [[deps.IrrationalConstants]]
@@ -343,9 +344,9 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.LogExpFunctions]]
 deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "7d6dd4e9212aebaeed356de34ccf262a3cd415aa"
+git-tree-sha1 = "18144f3e9cbe9b15b070288eef858f71b291ce37"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.26"
+version = "0.3.27"
 
     [deps.LogExpFunctions.extensions]
     LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
@@ -472,9 +473,9 @@ version = "1.2.0"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "00805cd429dcb4870060ff49ef443486c262e38e"
+git-tree-sha1 = "9e8fed0505b0c15b4c1295fd59ea47b411c019cf"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.4.1"
+version = "1.4.2"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -534,9 +535,9 @@ version = "2.3.1"
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
-git-tree-sha1 = "7b0e9c14c624e435076d19aea1e5cbdec2b9ca37"
+git-tree-sha1 = "bf074c045d3d5ffd956fa0a461da38a44685d6b2"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.2"
+version = "1.9.3"
 
     [deps.StaticArrays.extensions]
     StaticArraysChainRulesCoreExt = "ChainRulesCore"

--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 set -euo pipefail
 
-RESOLVE=false
+args=$@
 source ./juliaversion
 juliaversion=$RossbyWaveJuliaVersion
 VERSIONFLAG=false
@@ -18,8 +18,9 @@ if [ $VERSIONFLAG == false ]; then
     shift $((OPTIND - 1))
     juliaversion=${1:-$juliaversion}
 fi
+echo "using Julia version $juliaversion"
 curl -fsSL https://install.julialang.org | sh -s -- --yes --default-channel=$juliaversion
-bash --rcfile ~/.bashrc -i ./installjulia.sh $@
+bash --rcfile ~/.bashrc -i ./installjulia.sh $args
 if [ $? == 0 ]; then
 	echo "Installation successful."
 	echo "You may want to either source your shell's rc script, or launch a new interactive shell."

--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -1,10 +1,18 @@
 #! /bin/bash
 set -euo pipefail
 
-curl -fsSL https://install.julialang.org | sh -s -- --yes
+RESOLVE=false
 source ./juliaversion
-juliaversion=${1:-$RossbyWaveJuliaVersion}
-bash --rcfile ~/.bashrc -i ./installjulia.sh $juliaversion
+juliaversion=$RossbyWaveJuliaVersion
+while getopts ":rv:" flag; do
+    case ${flag} in
+        v)
+            juliaversion=$OPTARG
+            ;;
+    esac
+done
+curl -fsSL https://install.julialang.org | sh -s -- --yes --default-channel=$juliaversion
+bash --rcfile ~/.bashrc -i ./installjulia.sh $@
 if [ $? == 0 ]; then
 	echo "Installation successful."
 	echo "You may want to either source your shell's rc script, or launch a new interactive shell."

--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -4,13 +4,20 @@ set -euo pipefail
 RESOLVE=false
 source ./juliaversion
 juliaversion=$RossbyWaveJuliaVersion
+VERSIONFLAG=false
 while getopts ":rv:" flag; do
     case ${flag} in
         v)
+            VERSIONFLAG=true
             juliaversion=$OPTARG
             ;;
     esac
 done
+# backward compatibility with version as a positional argument
+if [ $VERSIONFLAG == false ]; then
+    shift $((OPTIND - 1))
+    juliaversion=${1:-$juliaversion}
+fi
 curl -fsSL https://install.julialang.org | sh -s -- --yes --default-channel=$juliaversion
 bash --rcfile ~/.bashrc -i ./installjulia.sh $@
 if [ $? == 0 ]; then

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.1"
+julia_version = "1.10.2"
 manifest_format = "2.0"
 project_hash = "dcff7b54a44c6f6d6e836b2b36a719f291419039"
 
@@ -133,9 +133,9 @@ weakdeps = ["SparseArrays"]
 
 [[deps.BangBang]]
 deps = ["Accessors", "Compat", "ConstructionBase", "InitialValues", "LinearAlgebra", "Requires"]
-git-tree-sha1 = "ffe3b6222215a9cf7ce449ad0b91274787a801c3"
+git-tree-sha1 = "490e739172eb18f762e68dc3b928cad2a077983a"
 uuid = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
-version = "0.4.0"
+version = "0.4.1"
 
     [deps.BangBang.extensions]
     BangBangChainRulesCoreExt = "ChainRulesCore"
@@ -195,9 +195,9 @@ version = "1.0.2"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
-git-tree-sha1 = "75bd5b6fc5089df449b5d35fa501c846c9b6549b"
+git-tree-sha1 = "c955881e3c981181362ae4088b35995446298b80"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.12.0"
+version = "4.14.0"
 weakdeps = ["Dates", "LinearAlgebra"]
 
     [deps.Compat.extensions]
@@ -288,9 +288,9 @@ version = "0.9.3"
 
 [[deps.DomainSets]]
 deps = ["CompositeTypes", "IntervalSets", "LinearAlgebra", "Random", "StaticArrays"]
-git-tree-sha1 = "4d18ed7069d7fc137089394b88eeedf7b5409120"
+git-tree-sha1 = "72bb555dc909a0932325f7dcc8c046ecb5dd39c8"
 uuid = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
-version = "0.7.3"
+version = "0.7.7"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
@@ -389,12 +389,6 @@ deps = ["Artifacts", "Libdl"]
 uuid = "781609d7-10c4-51f6-84f2-b8444358ff6d"
 version = "6.2.1+6"
 
-[[deps.GPUArraysCore]]
-deps = ["Adapt"]
-git-tree-sha1 = "ec632f177c0d990e64d955ccc1b8c04c485a0950"
-uuid = "46192b85-c4d5-4398-a991-12ede77f4527"
-version = "0.1.6"
-
 [[deps.GenericFFT]]
 deps = ["AbstractFFTs", "FFTW", "LinearAlgebra", "Reexport"]
 git-tree-sha1 = "1bc01f2ea9a0226a60723794ff86b8017739f5d9"
@@ -428,23 +422,24 @@ uuid = "22cec73e-a1b8-11e9-2c92-598750a2cf9c"
 version = "0.3.1"
 
 [[deps.IntelOpenMP_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "ad37c091f7d7daf900963171600d7c1c5c3ede32"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "5fdf2fe6724d8caabf43b557b84ce53f3b7e2f6b"
 uuid = "1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0"
-version = "2023.2.0+0"
+version = "2024.0.2+0"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[deps.IntervalSets]]
-git-tree-sha1 = "581191b15bcb56a2aa257e9c160085d0f128a380"
+git-tree-sha1 = "dba9ddf07f77f60450fe5d2e2beb9854d9a49bd0"
 uuid = "8197267c-284f-5f27-9208-e0e47529a953"
-version = "0.7.9"
-weakdeps = ["Random", "Statistics"]
+version = "0.7.10"
+weakdeps = ["Random", "RecipesBase", "Statistics"]
 
     [deps.IntervalSets.extensions]
     IntervalSetsRandomExt = "Random"
+    IntervalSetsRecipesBaseExt = "RecipesBase"
     IntervalSetsStatisticsExt = "Statistics"
 
 [[deps.InverseFunctions]]
@@ -470,9 +465,9 @@ version = "1.0.0"
 
 [[deps.JLD2]]
 deps = ["FileIO", "MacroTools", "Mmap", "OrderedCollections", "Pkg", "PrecompileTools", "Printf", "Reexport", "Requires", "TranscodingStreams", "UUIDs"]
-git-tree-sha1 = "7c0008f0b7622c6c0ee5c65cbc667b69f8a65672"
+git-tree-sha1 = "5ea6acdd53a51d897672edb694e3cc2912f3f8a7"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.4.45"
+version = "0.4.46"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
@@ -539,9 +534,9 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.LogExpFunctions]]
 deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "7d6dd4e9212aebaeed356de34ccf262a3cd415aa"
+git-tree-sha1 = "18144f3e9cbe9b15b070288eef858f71b291ce37"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.26"
+version = "0.3.27"
 
     [deps.LogExpFunctions.extensions]
     LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
@@ -567,16 +562,16 @@ weakdeps = ["FillArrays"]
     LowRankMatricesFillArraysExt = "FillArrays"
 
 [[deps.MKL]]
-deps = ["Artifacts", "Libdl", "LinearAlgebra", "MKL_jll"]
-git-tree-sha1 = "0e25aae49a4a43b3a03eb7ac7aba8473c60a87d2"
+deps = ["Artifacts", "Libdl", "LinearAlgebra", "Logging", "MKL_jll"]
+git-tree-sha1 = "17f06b6fb5198b757413d8379bfa62246c5da5a3"
 uuid = "33e6dc65-8f57-5167-99aa-e5a354878fb2"
-version = "0.6.2"
+version = "0.6.3"
 
 [[deps.MKL_jll]]
-deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
-git-tree-sha1 = "eb006abbd7041c28e0d16260e50a24f8f9104913"
+deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl"]
+git-tree-sha1 = "72dc3cf284559eb8f53aa593fe62cb33f83ed0c0"
 uuid = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
-version = "2023.2.0+0"
+version = "2024.0.0+0"
 
 [[deps.MPFR_jll]]
 deps = ["Artifacts", "GMP_jll", "Libdl"]
@@ -697,9 +692,9 @@ version = "1.2.0"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "00805cd429dcb4870060ff49ef443486c262e38e"
+git-tree-sha1 = "9e8fed0505b0c15b4c1295fd59ea47b411c019cf"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.4.1"
+version = "1.4.2"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -777,9 +772,9 @@ version = "0.1.15"
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
-git-tree-sha1 = "7b0e9c14c624e435076d19aea1e5cbdec2b9ca37"
+git-tree-sha1 = "bf074c045d3d5ffd956fa0a461da38a44685d6b2"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.2"
+version = "1.9.3"
 
     [deps.StaticArrays.extensions]
     StaticArraysChainRulesCoreExt = "ChainRulesCore"
@@ -800,10 +795,22 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 version = "1.10.0"
 
 [[deps.StructArrays]]
-deps = ["Adapt", "ConstructionBase", "DataAPI", "GPUArraysCore", "StaticArraysCore", "Tables"]
-git-tree-sha1 = "1b0b1205a56dc288b71b1961d48e351520702e24"
+deps = ["ConstructionBase", "DataAPI", "Tables"]
+git-tree-sha1 = "f4dc295e983502292c4c3f951dbb4e985e35b3be"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.17"
+version = "0.6.18"
+
+    [deps.StructArrays.extensions]
+    StructArraysAdaptExt = "Adapt"
+    StructArraysGPUArraysCoreExt = "GPUArraysCore"
+    StructArraysSparseArraysExt = "SparseArrays"
+    StructArraysStaticArraysExt = "StaticArrays"
+
+    [deps.StructArrays.weakdeps]
+    Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+    GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [[deps.SuiteSparse_jll]]
 deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ A Julia code to compute the spectrum of solar inertial waves, including realisti
 [Click here](https://jishnub.github.io/RossbyWaveSpectrum.jl/dev) for the documentation.
 
 # Installation
-To install the code, run `./INSTALL.sh`. This requires `bash` and `curl` to run, and will download and install `julia` using the installer `juliaup`. It will also install the requisite project dependencies. The project uses Julia v1.10.1, which may be installed independently as well, in which case one only needs to instantiate the environments as listed in `INSTALL.sh`.
+To install the code, run `./INSTALL.sh`. This requires `bash` and `curl` to run, and will download and install `julia` using the installer `juliaup`. It will also install the requisite project dependencies. The project uses Julia v1.10.2, which may be installed independently as well, in which case one only needs to instantiate the environments as listed in `installjulia.sh`.
 
-One may install the code for a specific Julia version using `./INSTALL.sh version`, e.g. for julia version `1.10.0` as `./INSTALL.sh 1.10.0`. This will instantiate the environments accordingly, and will also set up the jobscripts to use the specified version of Julia.
+One may install the code for a specific Julia version using `./INSTALL.sh -v version`, e.g. for julia version `1.10.0` as `./INSTALL.sh -v 1.10.0`. This will instantiate the environments accordingly, and will also set up the jobscripts to use the specified version of Julia. If you also wish to resolve the environments (i.e. fetch those dependencies that are compatible with the Julia version), then you may pass the flag `-r` to `INSTALL.sh`. This may be necessary if the dependnecy versions that were used while developing the project are incompatible with the julia version that is to be installed. Note that changing the dependency versions may lead to bugs or to the results being non-replicable (although this should usually not be the case).
 
 Users running the code on a heterogeneous cluster (where the login and compute nodes have different CPU architectures) may want to set the environment variable `JULIA_CPU_TARGET` appropriately in their shell rc file. One may check the CPU architecture by running
 ```julia

--- a/RossbyPlots/Manifest.toml
+++ b/RossbyPlots/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.1"
+julia_version = "1.10.2"
 manifest_format = "2.0"
 project_hash = "802de860db575f8b5f0fbbe6df1282c8c47bcd64"
 
@@ -130,9 +130,9 @@ weakdeps = ["SparseArrays"]
 
 [[deps.BangBang]]
 deps = ["Accessors", "Compat", "ConstructionBase", "InitialValues", "LinearAlgebra", "Requires"]
-git-tree-sha1 = "ffe3b6222215a9cf7ce449ad0b91274787a801c3"
+git-tree-sha1 = "490e739172eb18f762e68dc3b928cad2a077983a"
 uuid = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
-version = "0.4.0"
+version = "0.4.1"
 
     [deps.BangBang.extensions]
     BangBangChainRulesCoreExt = "ChainRulesCore"
@@ -187,9 +187,9 @@ version = "0.5.1"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra"]
-git-tree-sha1 = "ad25e7d21ce10e01de973cdc68ad0f850a953c52"
+git-tree-sha1 = "575cd02e080939a33b6df6c5853d14924c08e35b"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.21.1"
+version = "1.23.0"
 weakdeps = ["SparseArrays"]
 
     [deps.ChainRulesCore.extensions]
@@ -219,9 +219,9 @@ version = "0.2.4"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
-git-tree-sha1 = "75bd5b6fc5089df449b5d35fa501c846c9b6549b"
+git-tree-sha1 = "c955881e3c981181362ae4088b35995446298b80"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.12.0"
+version = "4.14.0"
 weakdeps = ["Dates", "LinearAlgebra"]
 
     [deps.Compat.extensions]
@@ -318,9 +318,9 @@ version = "0.9.3"
 
 [[deps.DomainSets]]
 deps = ["CompositeTypes", "IntervalSets", "LinearAlgebra", "Random", "StaticArrays"]
-git-tree-sha1 = "4d18ed7069d7fc137089394b88eeedf7b5409120"
+git-tree-sha1 = "72bb555dc909a0932325f7dcc8c046ecb5dd39c8"
 uuid = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
-version = "0.7.3"
+version = "0.7.7"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
@@ -425,12 +425,6 @@ deps = ["Artifacts", "Libdl"]
 uuid = "781609d7-10c4-51f6-84f2-b8444358ff6d"
 version = "6.2.1+6"
 
-[[deps.GPUArraysCore]]
-deps = ["Adapt"]
-git-tree-sha1 = "ec632f177c0d990e64d955ccc1b8c04c485a0950"
-uuid = "46192b85-c4d5-4398-a991-12ede77f4527"
-version = "0.1.6"
-
 [[deps.GenericFFT]]
 deps = ["AbstractFFTs", "FFTW", "LinearAlgebra", "Reexport"]
 git-tree-sha1 = "1bc01f2ea9a0226a60723794ff86b8017739f5d9"
@@ -464,23 +458,24 @@ uuid = "22cec73e-a1b8-11e9-2c92-598750a2cf9c"
 version = "0.3.1"
 
 [[deps.IntelOpenMP_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "ad37c091f7d7daf900963171600d7c1c5c3ede32"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "5fdf2fe6724d8caabf43b557b84ce53f3b7e2f6b"
 uuid = "1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0"
-version = "2023.2.0+0"
+version = "2024.0.2+0"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[deps.IntervalSets]]
-git-tree-sha1 = "581191b15bcb56a2aa257e9c160085d0f128a380"
+git-tree-sha1 = "dba9ddf07f77f60450fe5d2e2beb9854d9a49bd0"
 uuid = "8197267c-284f-5f27-9208-e0e47529a953"
-version = "0.7.9"
-weakdeps = ["Random", "Statistics"]
+version = "0.7.10"
+weakdeps = ["Random", "RecipesBase", "Statistics"]
 
     [deps.IntervalSets.extensions]
     IntervalSetsRandomExt = "Random"
+    IntervalSetsRecipesBaseExt = "RecipesBase"
     IntervalSetsStatisticsExt = "Statistics"
 
 [[deps.InverseFunctions]]
@@ -506,9 +501,9 @@ version = "1.0.0"
 
 [[deps.JLD2]]
 deps = ["FileIO", "MacroTools", "Mmap", "OrderedCollections", "Pkg", "PrecompileTools", "Printf", "Reexport", "Requires", "TranscodingStreams", "UUIDs"]
-git-tree-sha1 = "7c0008f0b7622c6c0ee5c65cbc667b69f8a65672"
+git-tree-sha1 = "5ea6acdd53a51d897672edb694e3cc2912f3f8a7"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.4.45"
+version = "0.4.46"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
@@ -586,9 +581,9 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.LogExpFunctions]]
 deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "7d6dd4e9212aebaeed356de34ccf262a3cd415aa"
+git-tree-sha1 = "18144f3e9cbe9b15b070288eef858f71b291ce37"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.26"
+version = "0.3.27"
 
     [deps.LogExpFunctions.extensions]
     LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
@@ -614,16 +609,16 @@ weakdeps = ["FillArrays"]
     LowRankMatricesFillArraysExt = "FillArrays"
 
 [[deps.MKL]]
-deps = ["Artifacts", "Libdl", "LinearAlgebra", "MKL_jll"]
-git-tree-sha1 = "0e25aae49a4a43b3a03eb7ac7aba8473c60a87d2"
+deps = ["Artifacts", "Libdl", "LinearAlgebra", "Logging", "MKL_jll"]
+git-tree-sha1 = "17f06b6fb5198b757413d8379bfa62246c5da5a3"
 uuid = "33e6dc65-8f57-5167-99aa-e5a354878fb2"
-version = "0.6.2"
+version = "0.6.3"
 
 [[deps.MKL_jll]]
-deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
-git-tree-sha1 = "eb006abbd7041c28e0d16260e50a24f8f9104913"
+deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl"]
+git-tree-sha1 = "72dc3cf284559eb8f53aa593fe62cb33f83ed0c0"
 uuid = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
-version = "2023.2.0+0"
+version = "2024.0.0+0"
 
 [[deps.MPFR_jll]]
 deps = ["Artifacts", "GMP_jll", "Libdl"]
@@ -750,9 +745,9 @@ version = "1.2.0"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "00805cd429dcb4870060ff49ef443486c262e38e"
+git-tree-sha1 = "9e8fed0505b0c15b4c1295fd59ea47b411c019cf"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.4.1"
+version = "1.4.2"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -864,9 +859,9 @@ version = "0.1.15"
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
-git-tree-sha1 = "7b0e9c14c624e435076d19aea1e5cbdec2b9ca37"
+git-tree-sha1 = "bf074c045d3d5ffd956fa0a461da38a44685d6b2"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.2"
+version = "1.9.3"
 weakdeps = ["ChainRulesCore", "Statistics"]
 
     [deps.StaticArrays.extensions]
@@ -884,10 +879,22 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 version = "1.10.0"
 
 [[deps.StructArrays]]
-deps = ["Adapt", "ConstructionBase", "DataAPI", "GPUArraysCore", "StaticArraysCore", "Tables"]
-git-tree-sha1 = "1b0b1205a56dc288b71b1961d48e351520702e24"
+deps = ["ConstructionBase", "DataAPI", "Tables"]
+git-tree-sha1 = "f4dc295e983502292c4c3f951dbb4e985e35b3be"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.17"
+version = "0.6.18"
+
+    [deps.StructArrays.extensions]
+    StructArraysAdaptExt = "Adapt"
+    StructArraysGPUArraysCoreExt = "GPUArraysCore"
+    StructArraysSparseArraysExt = "SparseArrays"
+    StructArraysStaticArraysExt = "StaticArrays"
+
+    [deps.StructArrays.weakdeps]
+    Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+    GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [[deps.SuiteSparse_jll]]
 deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.1"
+julia_version = "1.10.2"
 manifest_format = "2.0"
 project_hash = "338bf815e5be29aad3c985453521d81e154717a7"
 
@@ -21,9 +21,9 @@ weakdeps = ["ChainRulesCore", "Test"]
     AbstractFFTsTestExt = "Test"
 
 [[deps.AbstractTrees]]
-git-tree-sha1 = "faa260e4cb5aba097a73fab382dd4b5819d8ec8c"
+git-tree-sha1 = "2d9c9a55f9c93e8887ad391fbae72f8ef55e1177"
 uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
-version = "0.4.4"
+version = "0.4.5"
 
 [[deps.Accessors]]
 deps = ["CompositionsBase", "ConstructionBase", "Dates", "InverseFunctions", "LinearAlgebra", "MacroTools", "Test"]
@@ -140,9 +140,9 @@ weakdeps = ["SparseArrays"]
 
 [[deps.BangBang]]
 deps = ["Accessors", "Compat", "ConstructionBase", "InitialValues", "LinearAlgebra", "Requires"]
-git-tree-sha1 = "ffe3b6222215a9cf7ce449ad0b91274787a801c3"
+git-tree-sha1 = "490e739172eb18f762e68dc3b928cad2a077983a"
 uuid = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
-version = "0.4.0"
+version = "0.4.1"
 
     [deps.BangBang.extensions]
     BangBangChainRulesCoreExt = "ChainRulesCore"
@@ -197,9 +197,9 @@ version = "0.5.1"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra"]
-git-tree-sha1 = "ad25e7d21ce10e01de973cdc68ad0f850a953c52"
+git-tree-sha1 = "575cd02e080939a33b6df6c5853d14924c08e35b"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.21.1"
+version = "1.23.0"
 weakdeps = ["SparseArrays"]
 
     [deps.ChainRulesCore.extensions]
@@ -229,9 +229,9 @@ version = "0.2.4"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
-git-tree-sha1 = "75bd5b6fc5089df449b5d35fa501c846c9b6549b"
+git-tree-sha1 = "c955881e3c981181362ae4088b35995446298b80"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.12.0"
+version = "4.14.0"
 weakdeps = ["Dates", "LinearAlgebra"]
 
     [deps.Compat.extensions]
@@ -334,9 +334,9 @@ version = "1.2.1"
 
 [[deps.DomainSets]]
 deps = ["CompositeTypes", "IntervalSets", "LinearAlgebra", "Random", "StaticArrays"]
-git-tree-sha1 = "4d18ed7069d7fc137089394b88eeedf7b5409120"
+git-tree-sha1 = "72bb555dc909a0932325f7dcc8c046ecb5dd39c8"
 uuid = "5b8099bc-c8ec-5219-889f-1d9e522a28bf"
-version = "0.7.3"
+version = "0.7.7"
 
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
@@ -447,12 +447,6 @@ deps = ["Artifacts", "Libdl"]
 uuid = "781609d7-10c4-51f6-84f2-b8444358ff6d"
 version = "6.2.1+6"
 
-[[deps.GPUArraysCore]]
-deps = ["Adapt"]
-git-tree-sha1 = "ec632f177c0d990e64d955ccc1b8c04c485a0950"
-uuid = "46192b85-c4d5-4398-a991-12ede77f4527"
-version = "0.1.6"
-
 [[deps.GenericFFT]]
 deps = ["AbstractFFTs", "FFTW", "LinearAlgebra", "Reexport"]
 git-tree-sha1 = "1bc01f2ea9a0226a60723794ff86b8017739f5d9"
@@ -461,15 +455,15 @@ version = "0.1.6"
 
 [[deps.Git]]
 deps = ["Git_jll"]
-git-tree-sha1 = "51764e6c2e84c37055e846c516e9015b4a291c7d"
+git-tree-sha1 = "04eff47b1354d702c3a85e8ab23d539bb7d5957e"
 uuid = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
-version = "1.3.0"
+version = "1.3.1"
 
 [[deps.Git_jll]]
 deps = ["Artifacts", "Expat_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Libiconv_jll", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
-git-tree-sha1 = "b30c473c97fcc1e1e44fab8f3e88fd1b89c9e9d1"
+git-tree-sha1 = "12945451c5d0e2d0dca0724c3a8d6448b46bbdf9"
 uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
-version = "2.43.0+0"
+version = "2.44.0+1"
 
 [[deps.HalfIntegers]]
 git-tree-sha1 = "1cfb497b72e1e8ab2256334dee1aaad43fa279ad"
@@ -504,23 +498,24 @@ uuid = "22cec73e-a1b8-11e9-2c92-598750a2cf9c"
 version = "0.3.1"
 
 [[deps.IntelOpenMP_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "ad37c091f7d7daf900963171600d7c1c5c3ede32"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "5fdf2fe6724d8caabf43b557b84ce53f3b7e2f6b"
 uuid = "1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0"
-version = "2023.2.0+0"
+version = "2024.0.2+0"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[deps.IntervalSets]]
-git-tree-sha1 = "581191b15bcb56a2aa257e9c160085d0f128a380"
+git-tree-sha1 = "dba9ddf07f77f60450fe5d2e2beb9854d9a49bd0"
 uuid = "8197267c-284f-5f27-9208-e0e47529a953"
-version = "0.7.9"
-weakdeps = ["Random", "Statistics"]
+version = "0.7.10"
+weakdeps = ["Random", "RecipesBase", "Statistics"]
 
     [deps.IntervalSets.extensions]
     IntervalSetsRandomExt = "Random"
+    IntervalSetsRecipesBaseExt = "RecipesBase"
     IntervalSetsStatisticsExt = "Statistics"
 
 [[deps.InverseFunctions]]
@@ -546,9 +541,9 @@ version = "1.0.0"
 
 [[deps.JLD2]]
 deps = ["FileIO", "MacroTools", "Mmap", "OrderedCollections", "Pkg", "PrecompileTools", "Printf", "Reexport", "Requires", "TranscodingStreams", "UUIDs"]
-git-tree-sha1 = "7c0008f0b7622c6c0ee5c65cbc667b69f8a65672"
+git-tree-sha1 = "5ea6acdd53a51d897672edb694e3cc2912f3f8a7"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.4.45"
+version = "0.4.46"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
@@ -637,9 +632,9 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[deps.LogExpFunctions]]
 deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "7d6dd4e9212aebaeed356de34ccf262a3cd415aa"
+git-tree-sha1 = "18144f3e9cbe9b15b070288eef858f71b291ce37"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.26"
+version = "0.3.27"
 
     [deps.LogExpFunctions.extensions]
     LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
@@ -665,16 +660,16 @@ weakdeps = ["FillArrays"]
     LowRankMatricesFillArraysExt = "FillArrays"
 
 [[deps.MKL]]
-deps = ["Artifacts", "Libdl", "LinearAlgebra", "MKL_jll"]
-git-tree-sha1 = "0e25aae49a4a43b3a03eb7ac7aba8473c60a87d2"
+deps = ["Artifacts", "Libdl", "LinearAlgebra", "Logging", "MKL_jll"]
+git-tree-sha1 = "17f06b6fb5198b757413d8379bfa62246c5da5a3"
 uuid = "33e6dc65-8f57-5167-99aa-e5a354878fb2"
-version = "0.6.2"
+version = "0.6.3"
 
 [[deps.MKL_jll]]
-deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
-git-tree-sha1 = "eb006abbd7041c28e0d16260e50a24f8f9104913"
+deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl"]
+git-tree-sha1 = "72dc3cf284559eb8f53aa593fe62cb33f83ed0c0"
 uuid = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
-version = "2023.2.0+0"
+version = "2024.0.0+0"
 
 [[deps.MPFR_jll]]
 deps = ["Artifacts", "GMP_jll", "Libdl"]
@@ -818,9 +813,9 @@ version = "1.2.0"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "00805cd429dcb4870060ff49ef443486c262e38e"
+git-tree-sha1 = "9e8fed0505b0c15b4c1295fd59ea47b411c019cf"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.4.1"
+version = "1.4.2"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -945,9 +940,9 @@ version = "0.1.15"
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
-git-tree-sha1 = "7b0e9c14c624e435076d19aea1e5cbdec2b9ca37"
+git-tree-sha1 = "bf074c045d3d5ffd956fa0a461da38a44685d6b2"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.2"
+version = "1.9.3"
 weakdeps = ["ChainRulesCore", "Statistics"]
 
     [deps.StaticArrays.extensions]
@@ -965,10 +960,22 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 version = "1.10.0"
 
 [[deps.StructArrays]]
-deps = ["Adapt", "ConstructionBase", "DataAPI", "GPUArraysCore", "StaticArraysCore", "Tables"]
-git-tree-sha1 = "1b0b1205a56dc288b71b1961d48e351520702e24"
+deps = ["ConstructionBase", "DataAPI", "Tables"]
+git-tree-sha1 = "f4dc295e983502292c4c3f951dbb4e985e35b3be"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.17"
+version = "0.6.18"
+
+    [deps.StructArrays.extensions]
+    StructArraysAdaptExt = "Adapt"
+    StructArraysGPUArraysCoreExt = "GPUArraysCore"
+    StructArraysSparseArraysExt = "SparseArrays"
+    StructArraysStaticArraysExt = "StaticArrays"
+
+    [deps.StructArrays.weakdeps]
+    Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+    GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [[deps.SuiteSparse_jll]]
 deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,9 +3,9 @@
 A Julia code to compute the spectrum of inertial waves in the Sun.
 
 # Installation
-To install the code, run `./INSTALL.sh`. This requires `bash` and `curl` to run, and will download and install `julia` using the installer `juliaup`. It will also install the requisite project dependencies. The project uses Julia v1.10.1, which may be installed independently as well, in which case one only needs to instantiate the environments as listed in `INSTALL.sh`.
+To install the code, run `./INSTALL.sh`. This requires `bash` and `curl` to run, and will download and install `julia` using the installer `juliaup`. It will also install the requisite project dependencies. The project uses Julia v1.10.2, which may be installed independently as well, in which case one only needs to instantiate the environments as listed in `installjulia.sh`.
 
-One may install the code for a specific Julia version using `./INSTALL.sh version`, e.g. for julia version `1.10.0` as `./INSTALL.sh 1.10.0`. This will instantiate the environments accordingly, and will also set up the jobscripts to use the specified version of Julia.
+You may install the code for a specific Julia version using `./INSTALL.sh -v version`, e.g. for julia version `1.10.0` as `./INSTALL.sh -v 1.10.0`. This will instantiate the environments accordingly, and will also set up the jobscripts to use the specified version of Julia. If you also wish to resolve the environments (i.e. fetch those dependencies that are compatible with the specified Julia version), then you may pass the flag `-r` to `INSTALL.sh`. This may be necessary if the dependnecy versions that were used while developing the project are incompatible with the julia version that is to be installed. Note that changing the dependency versions may lead to bugs or to the results being non-replicable (although this should usually not be the case).
 
 A part of installation process requires `matplotlib` to be available. If one is using an anaconda distribution located in their user directory, they may need to export `PYTHON=<path to python>` before running `INSTALL.sh`. So, for example, one may run
 ```
@@ -31,7 +31,7 @@ if e.g. the login node has `skylake-avx512` and the compute node has `icelake-se
 Typically the code is run multi-threaded, so one needs to specify the number of threads while launching Julia.
 As an example, if we want to use `5` Julia threads, this may be done as
 ```
-julia +1.10.1 --project=. --startup-file=no -t 5
+julia +1.10.2 --project=. --startup-file=no -t 5
 ```
 The flag `--project` should point to the path to the code.
 The example above assumes that you are in the top-level code directory (`RossbyWaveSpectrum.jl`).

--- a/installjulia.sh
+++ b/installjulia.sh
@@ -1,8 +1,33 @@
 source ./juliaversion
-juliaversion=${1:-$RossbyWaveJuliaVersion}
+juliaversion=$RossbyWaveJuliaVersion
+RESOLVE=false
+while getopts ":rv:" flag; do
+    case ${flag} in
+        r)
+        	RESOLVE=true
+            ;;
+        v)
+            juliaversion=$OPTARG
+            ;;
+        ?)
+            echo "Invalid option: -${OPTARG}"
+            exit 1
+            ;;
+    esac
+done
 juliaup add $juliaversion
-julia +$juliaversion -e \
-'import Pkg;
-Pkg.activate("ApproxFunAssociatedLegendre"); Pkg.instantiate();
-Pkg.activate("."); Pkg.instantiate();
-Pkg.activate("RossbyPlots"); Pkg.instantiate();'
+if [ $RESOLVE == true ]; then
+	julia +$juliaversion -e \
+	'import Pkg;
+	Pkg.activate("ApproxFunAssociatedLegendre"); Pkg.resolve(); Pkg.instantiate();
+	Pkg.activate("."); Pkg.resolve(); Pkg.instantiate();
+	Pkg.activate("RossbyPlots"); Pkg.resolve(); Pkg.instantiate();
+	'
+else
+	julia +$juliaversion -e \
+	'import Pkg;
+	Pkg.activate("ApproxFunAssociatedLegendre"); Pkg.instantiate();
+	Pkg.activate("."); Pkg.instantiate();
+	Pkg.activate("RossbyPlots"); Pkg.instantiate();
+	'
+fi

--- a/installjulia.sh
+++ b/installjulia.sh
@@ -25,6 +25,7 @@ fi
 
 juliaup add $juliaversion
 if [ $RESOLVE == true ]; then
+	echo "Resolving environments on Julia version $juliaversion"
 	julia +$juliaversion -e \
 	'import Pkg;
 	Pkg.activate("ApproxFunAssociatedLegendre"); Pkg.resolve(); Pkg.instantiate();

--- a/installjulia.sh
+++ b/installjulia.sh
@@ -1,12 +1,14 @@
 source ./juliaversion
 juliaversion=$RossbyWaveJuliaVersion
 RESOLVE=false
+VERSIONFLAG=false
 while getopts ":rv:" flag; do
     case ${flag} in
         r)
         	RESOLVE=true
             ;;
         v)
+			VERSIONFLAG=true
             juliaversion=$OPTARG
             ;;
         ?)
@@ -15,6 +17,12 @@ while getopts ":rv:" flag; do
             ;;
     esac
 done
+# backward compatibility with version as a positional argument
+if [ $VERSIONFLAG == false ]; then
+	shift $((OPTIND - 1))
+	juliaversion=${1:-$juliaversion}
+fi
+
 juliaup add $juliaversion
 if [ $RESOLVE == true ]; then
 	julia +$juliaversion -e \

--- a/juliaversion
+++ b/juliaversion
@@ -1,1 +1,1 @@
-RossbyWaveJuliaVersion=1.10.1
+RossbyWaveJuliaVersion=1.10.2


### PR DESCRIPTION
This also changes how the julia version number is passed to `INSTALL.sh`. After this, one may install for a specific julia version using
```console
./INSTALL.sh -v 1.10.2
```
and also resolve packages using
```console
./INSTALL.sh -v 1.10.2 -r
```
The previous way of passing the version as the first argument is now unsupported.